### PR TITLE
refactor: integer indexing

### DIFF
--- a/zarrs/src/array/array_bytes.rs
+++ b/zarrs/src/array/array_bytes.rs
@@ -5,9 +5,8 @@ use thiserror::Error;
 use unsafe_cell_slice::UnsafeCellSlice;
 
 use crate::{
-    array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
-    byte_range::extract_byte_ranges_concat_unchecked,
-    metadata::v3::array::data_type::DataTypeSize,
+    array_subset::ArraySubset, byte_range::extract_byte_ranges_concat_unchecked,
+    indexer::IncompatibleIndexerAndShapeError, metadata::v3::array::data_type::DataTypeSize,
 };
 
 use super::{codec::CodecError, ravel_indices, ArraySize, DataType, FillValue};
@@ -169,7 +168,7 @@ impl<'a> ArrayBytes<'a> {
         match self {
             ArrayBytes::Variable(bytes, offsets) => {
                 let indices = subset.linearised_indices(array_shape).map_err(|_| {
-                    IncompatibleArraySubsetAndShapeError::new(subset.clone(), array_shape.to_vec())
+                    IncompatibleIndexerAndShapeError::new(subset.clone(), array_shape.to_vec())
                 })?;
                 let mut bytes_length = 0;
                 for index in &indices {
@@ -606,7 +605,6 @@ mod tests {
     use std::mem::size_of;
 
     use crate::array::Element;
-    use crate::array_subset::IndexingMethod;
 
     use super::*;
 
@@ -665,53 +663,55 @@ mod tests {
 
     #[test]
     fn test_flen_update_subset_vindex() {
-        let mut bytes_array = vec![0u8; 4 * 4];
-        {
-            let bytes_array = UnsafeCellSlice::new(&mut bytes_array);
-            update_bytes_flen(
-                &bytes_array,
-                &vec![4, 4],
-                &vec![1, 2].into(),
-                &ArraySubset::new_with_start_shape_indices(
-                    vec![0, 0],
-                    vec![Some(vec![0, 2]), Some(vec![0, 2])],
-                    vec![2, 1],
-                    IndexingMethod::VIndex,
-                )
-                .unwrap(),
-                1,
-            );
-        }
+        todo!("integer indexing")
+        // let mut bytes_array = vec![0u8; 4 * 4];
+        // {
+        //     let bytes_array = UnsafeCellSlice::new(&mut bytes_array);
+        //     update_bytes_flen(
+        //         &bytes_array,
+        //         &vec![4, 4],
+        //         &vec![1, 2].into(),
+        //         &ArraySubset::new_with_start_shape_indices(
+        //             vec![0, 0],
+        //             vec![Some(vec![0, 2]), Some(vec![0, 2])],
+        //             vec![2, 1],
+        //             IndexingMethod::VIndex,
+        //         )
+        //         .unwrap(),
+        //         1,
+        //     );
+        // }
 
-        debug_assert_eq!(
-            bytes_array,
-            vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0]
-        );
+        // debug_assert_eq!(
+        //     bytes_array,
+        //     vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0]
+        // );
     }
 
     #[test]
     fn test_flen_update_subset_mixed() {
-        let mut bytes_array = vec![0u8; 4 * 4];
-        {
-            let bytes_array = UnsafeCellSlice::new(&mut bytes_array);
-            update_bytes_flen(
-                &bytes_array,
-                &vec![4, 4],
-                &vec![1, 2, 3, 4, 5, 6, 7, 8].into(),
-                &ArraySubset::new_with_start_shape_indices(
-                    vec![0, 0],
-                    vec![Some(vec![0, 2]), None],
-                    vec![2, 4],
-                    IndexingMethod::Mixed,
-                )
-                .unwrap(),
-                1,
-            );
-        }
+        todo!("integer indexing");
+        // let mut bytes_array = vec![0u8; 4 * 4];
+        // {
+        //     let bytes_array = UnsafeCellSlice::new(&mut bytes_array);
+        //     update_bytes_flen(
+        //         &bytes_array,
+        //         &vec![4, 4],
+        //         &vec![1, 2, 3, 4, 5, 6, 7, 8].into(),
+        //         &ArraySubset::new_with_start_shape_indices(
+        //             vec![0, 0],
+        //             vec![Some(vec![0, 2]), None],
+        //             vec![2, 4],
+        //             IndexingMethod::Mixed,
+        //         )
+        //         .unwrap(),
+        //         1,
+        //     );
+        // }
 
-        debug_assert_eq!(
-            bytes_array,
-            vec![1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8, 0, 0, 0, 0]
-        );
+        // debug_assert_eq!(
+        //     bytes_array,
+        //     vec![1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8, 0, 0, 0, 0]
+        // );
     }
 }

--- a/zarrs/src/array/array_bytes.rs
+++ b/zarrs/src/array/array_bytes.rs
@@ -672,7 +672,13 @@ mod tests {
                 &bytes_array,
                 &vec![4, 4],
                 &vec![1, 2].into(),
-                &ArraySubset::new_with_start_shape_indices(vec![0, 0], vec![Some(vec![0, 2]), Some(vec![0, 2])], vec![2, 1], IndexingMethod::VIndex).unwrap(),
+                &ArraySubset::new_with_start_shape_indices(
+                    vec![0, 0],
+                    vec![Some(vec![0, 2]), Some(vec![0, 2])],
+                    vec![2, 1],
+                    IndexingMethod::VIndex,
+                )
+                .unwrap(),
                 1,
             );
         }
@@ -692,7 +698,13 @@ mod tests {
                 &bytes_array,
                 &vec![4, 4],
                 &vec![1, 2, 3, 4, 5, 6, 7, 8].into(),
-                &ArraySubset::new_with_start_shape_indices(vec![0, 0], vec![Some(vec![0, 2]), None], vec![2, 4], IndexingMethod::Mixed).unwrap(),
+                &ArraySubset::new_with_start_shape_indices(
+                    vec![0, 0],
+                    vec![Some(vec![0, 2]), None],
+                    vec![2, 4],
+                    IndexingMethod::Mixed,
+                )
+                .unwrap(),
                 1,
             );
         }

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -78,9 +78,10 @@ pub use array_to_array_partial_encoder_default::ArrayToArrayPartialEncoderDefaul
 mod bytes_partial_encoder_default;
 pub use bytes_partial_encoder_default::BytesPartialEncoderDefault;
 
+use crate::indexer::IncompatibleIndexerAndShapeError;
 use crate::storage::{StoreKeyOffsetValue, WritableStorage};
 use crate::{
-    array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
+    array_subset::ArraySubset,
     byte_range::{extract_byte_ranges_read_seek, ByteOffset, ByteRange, InvalidByteRangeError},
     metadata::v3::MetadataV3,
     plugin::{Plugin, PluginCreateError},
@@ -969,9 +970,9 @@ pub enum CodecError {
     /// An invalid byte range was requested.
     #[error(transparent)]
     InvalidByteRangeError(#[from] InvalidByteRangeError),
-    /// An invalid array subset was requested.
+    /// An incompatible indexer and array shape error.
     #[error(transparent)]
-    InvalidArraySubsetError(#[from] IncompatibleArraySubsetAndShapeError),
+    InvalidIndexerError(#[from] IncompatibleIndexerAndShapeError),
     /// An invalid array subset was requested with the wrong dimensionality.
     #[error("the array subset {_0} has the wrong dimensionality, expected {_1}")]
     InvalidArraySubsetDimensionalityError(ArraySubset, usize),

--- a/zarrs/src/array/codec/array_to_array_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/array_to_array_partial_encoder_default.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use crate::{
     array::{array_bytes::update_array_bytes, ArrayBytes, ChunkRepresentation},
-    array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
+    array_subset::ArraySubset,
+    indexer::IncompatibleIndexerAndShapeError,
 };
 
 use super::{
@@ -73,8 +74,8 @@ impl ArrayPartialEncoderTraits for ArrayToArrayPartialEncoderDefault {
                 .zip(self.decoded_representation.shape())
                 .any(|(a, b)| *a > b.get())
             {
-                return Err(CodecError::InvalidArraySubsetError(
-                    IncompatibleArraySubsetAndShapeError::new(
+                return Err(CodecError::InvalidIndexerError(
+                    IncompatibleIndexerAndShapeError::new(
                         (*chunk_subset).clone(),
                         self.decoded_representation.shape_u64(),
                     ),

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         ArrayBytes, ArraySize, ChunkRepresentation, DataType, DataTypeSize,
     },
-    array_subset::IncompatibleArraySubsetAndShapeError,
+    indexer::IncompatibleIndexerAndShapeError,
 };
 
 #[cfg(feature = "async")]
@@ -63,10 +63,10 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder {
                     let byte_ranges = array_subset
                         .byte_ranges(&chunk_shape, data_type_size)
                         .map_err(|_| {
-                            IncompatibleArraySubsetAndShapeError::from((
+                            IncompatibleIndexerAndShapeError::new(
                                 array_subset.clone(),
                                 self.decoded_representation.shape_u64(),
-                            ))
+                            )
                         })?;
 
                     // Decode
@@ -171,10 +171,10 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
                 DataTypeSize::Fixed(data_type_size) => array_subset
                     .byte_ranges(&chunk_shape, data_type_size)
                     .map_err(|_| {
-                        IncompatibleArraySubsetAndShapeError::from((
+                        IncompatibleIndexerAndShapeError::new(
                             array_subset.clone(),
                             self.decoded_representation.shape_u64(),
-                        ))
+                        )
                     })?,
             };
 

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -21,8 +21,9 @@ use crate::{
         ravel_indices, transmute_to_bytes, ArrayBytes, ArraySize, ChunkRepresentation, ChunkShape,
         CodecChain, RawBytes,
     },
-    array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
+    array_subset::ArraySubset,
     byte_range::ByteRange,
+    indexer::IncompatibleIndexerAndShapeError,
 };
 
 use super::{sharding_index_decoded_representation, ShardingIndexLocation};
@@ -132,7 +133,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
             self.chunk_grid
                 .chunks_in_array_subset(chunk_subset, &chunks_per_shard)
                 .map_err(|_| {
-                    CodecError::InvalidArraySubsetError(IncompatibleArraySubsetAndShapeError::new(
+                    CodecError::InvalidIndexerError(IncompatibleIndexerAndShapeError::new(
                         (*chunk_subset).clone(),
                         chunks_per_shard.clone(),
                     ))
@@ -167,8 +168,8 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                 .zip(self.decoded_representation.shape())
                 .any(|(a, b)| *a > b.get())
             {
-                return Err(CodecError::InvalidArraySubsetError(
-                    IncompatibleArraySubsetAndShapeError::new(
+                return Err(CodecError::InvalidIndexerError(
+                    IncompatibleIndexerAndShapeError::new(
                         (*chunk_subset).clone(),
                         self.decoded_representation.shape_u64(),
                     ),

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -17,32 +17,14 @@ use iterators::{
 };
 
 use derive_more::{Display, From};
-use itertools::{izip, Itertools};
+use itertools::izip;
 use thiserror::Error;
 
 use crate::{
     array::{ArrayIndices, ArrayShape},
+    indexer::IncompatibleIndexerAndShapeError,
     storage::byte_range::ByteRange,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-/// The different kinds of array indexing methods.
-///
-/// See: https://numpy.org/neps/nep-0021-advanced-indexing.html#existing-indexing-operations
-pub enum IndexingMethod {
-    /// Basic indexing i.e., no integer indices
-    #[default]
-    Basic,
-    /// Vectorized Indexing
-    VIndex,
-    /// Orthogonal Indexing
-    OIndex,
-    /// Mixed Indexing, a variant of vectorized where integer indices are treated as vectorized but with ranges too
-    Mixed,
-}
-
-/// Integer indices, if they exist, are represented as a `ArrayIndices` - otherwise None.
-pub type MaybeIntegerIndices = Vec<Option<ArrayIndices>>;
 
 /// An array subset.
 ///
@@ -53,10 +35,6 @@ pub struct ArraySubset {
     start: ArrayIndices,
     /// The shape of the array subset.
     shape: ArrayShape,
-    /// Integer indices
-    integer_indices: MaybeIntegerIndices,
-    /// Indexing method
-    pub indexing_method: IndexingMethod,
 }
 
 impl Display for ArraySubset {
@@ -72,8 +50,6 @@ impl ArraySubset {
         Self {
             start: vec![0; dimensionality],
             shape: vec![0; dimensionality],
-            integer_indices: vec![None; dimensionality],
-            indexing_method: IndexingMethod::Basic,
         }
     }
 
@@ -82,24 +58,15 @@ impl ArraySubset {
     pub fn new_with_ranges(ranges: &[Range<u64>]) -> Self {
         let start = ranges.iter().map(|range| range.start).collect();
         let shape = ranges.iter().map(|range| range.end - range.start).collect();
-        let len = ranges.len();
-        Self {
-            start,
-            shape,
-            integer_indices: vec![None; len],
-            indexing_method: IndexingMethod::Basic,
-        }
+        Self { start, shape }
     }
 
     /// Create a new array subset with `size` starting at the origin.
     #[must_use]
     pub fn new_with_shape(shape: ArrayShape) -> Self {
-        let len = shape.len();
         Self {
-            start: vec![0; len],
+            start: vec![0; shape.len()],
             shape,
-            integer_indices: vec![None; len],
-            indexing_method: IndexingMethod::Basic,
         }
     }
 
@@ -112,14 +79,8 @@ impl ArraySubset {
         start: ArrayIndices,
         shape: ArrayShape,
     ) -> Result<Self, IncompatibleDimensionalityError> {
-        let len = start.len();
         if start.len() == shape.len() {
-            Ok(Self {
-                start,
-                shape,
-                integer_indices: vec![None; len],
-                indexing_method: IndexingMethod::Basic,
-            })
+            Ok(Self { start, shape })
         } else {
             Err(IncompatibleDimensionalityError::new(
                 start.len(),
@@ -135,13 +96,7 @@ impl ArraySubset {
     #[must_use]
     pub unsafe fn new_with_start_shape_unchecked(start: ArrayIndices, shape: ArrayShape) -> Self {
         debug_assert_eq!(start.len(), shape.len());
-        let len = start.len();
-        Self {
-            start,
-            shape,
-            integer_indices: vec![None; len],
-            indexing_method: IndexingMethod::Basic,
-        }
+        Self { start, shape }
     }
 
     /// Create a new array subset from a start and end (inclusive).
@@ -167,19 +122,13 @@ impl ArraySubset {
     #[must_use]
     pub unsafe fn new_with_start_end_inc_unchecked(start: ArrayIndices, end: ArrayIndices) -> Self {
         debug_assert_eq!(start.len(), end.len());
-        let len = start.len();
         let shape = std::iter::zip(&start, end)
             .map(|(&start, end)| {
                 debug_assert!(end >= start);
                 end.saturating_sub(start) + 1
             })
             .collect();
-        Self {
-            start,
-            shape,
-            integer_indices: vec![None; len],
-            indexing_method: IndexingMethod::Basic,
-        }
+        Self { start, shape }
     }
 
     /// Create a new array subset from a start and end (exclusive).
@@ -205,90 +154,13 @@ impl ArraySubset {
     #[must_use]
     pub unsafe fn new_with_start_end_exc_unchecked(start: ArrayIndices, end: ArrayIndices) -> Self {
         debug_assert_eq!(start.len(), end.len());
-        let len = start.len();
         let shape = std::iter::zip(&start, end)
             .map(|(&start, end)| {
                 debug_assert!(end >= start);
                 end.saturating_sub(start)
             })
             .collect();
-        Self {
-            start,
-            shape,
-            integer_indices: vec![None; len],
-            indexing_method: IndexingMethod::Basic,
-        }
-    }
-
-    /// Create a new array subset from a start with integer array indices (or not), a shape to indicate where ranges should be used in the absence of integer indices, and an indexing method.
-    /// This function will error out if the dimensionalities do not line up, an incorrect indexing method is passed in given the integer indices, or the integer indices are incompatible with the shape.
-    #[must_use]
-    pub fn new_with_start_shape_indices(
-        start: ArrayIndices,
-        integer_indices: Vec<Option<ArrayIndices>>,
-        shape: ArrayShape,
-        indexing_method: IndexingMethod,
-    ) -> Result<Self, IntegerIndicesError> {
-        if start.len() != shape.len() {
-            return Err(IntegerIndicesError::IncompatibleDimensionalityError(
-                IncompatibleDimensionalityError::new(start.len(), shape.len()),
-            ));
-        }
-        if integer_indices.len() != shape.len() {
-            return Err(IntegerIndicesError::IncompatibleDimensionalityError(
-                IncompatibleDimensionalityError::new(integer_indices.len(), shape.len()),
-            ));
-        }
-        let all_none_integer_indices = integer_indices.iter().all(|x| x.is_none());
-        let all_some_integer_indices = integer_indices.iter().all(|x| x.is_some());
-        let any_none_integer_indices = integer_indices.iter().any(|x| x.is_none());
-        let is_vindex = indexing_method == IndexingMethod::VIndex;
-        let is_vindex_with_unequal_index_lengths = all_some_integer_indices
-            && is_vindex
-            && !integer_indices
-                .iter()
-                .map(|x| x.as_ref().unwrap().len())
-                .all_equal();
-        let is_vindex_with_bad_shape = all_some_integer_indices
-            && is_vindex
-            && (integer_indices[0].as_ref().unwrap().len() != (shape[0] as usize)
-                || shape.iter().skip(1).all_equal_value() != Ok(&1));
-        let is_incorrect_indexing_method = (all_none_integer_indices
-            && indexing_method != IndexingMethod::Basic)
-            || (!all_none_integer_indices
-                && any_none_integer_indices
-                && indexing_method != IndexingMethod::Mixed)
-            || (all_some_integer_indices && indexing_method == IndexingMethod::Basic)
-            || (any_none_integer_indices && is_vindex);
-        let are_integer_indices_wrong_or_missing =
-            izip!(&shape, &integer_indices).any(|(sh, index)| match index {
-                Some(i) => {
-                    i.len() == 0
-                        || (indexing_method == IndexingMethod::OIndex && i.len() as u64 != *sh)
-                }
-                None => *sh == 0,
-            });
-        if is_incorrect_indexing_method
-            || are_integer_indices_wrong_or_missing
-            || is_vindex_with_unequal_index_lengths
-            || is_vindex_with_bad_shape
-        {
-            return Err(IntegerIndicesError::IncompatibleIntegerIndicesError(
-                IncompatibleIntegerIndicesError::from((
-                    start,
-                    integer_indices,
-                    shape,
-                    indexing_method,
-                )),
-            ));
-        } else {
-            Ok(Self {
-                start,
-                shape,
-                integer_indices,
-                indexing_method,
-            })
-        }
+        Self { start, shape }
     }
 
     /// Return the array subset as a vec of ranges.
@@ -342,12 +214,6 @@ impl ArraySubset {
         &self.shape
     }
 
-    /// Return integer indices.
-    #[must_use]
-    pub fn integer_indices(&self) -> &[Option<ArrayIndices>] {
-        &self.integer_indices
-    }
-
     /// Return the shape of the array subset.
     ///
     /// # Panics
@@ -372,7 +238,7 @@ impl ArraySubset {
         self.start.len()
     }
 
-    /// Return the end (inclusive) of the array subset.  If there is an integer index at that position, 0 is used.
+    /// Return the end (inclusive) of the array subset.
     ///
     /// Returns [`None`] if the array subset is empty.
     #[must_use]
@@ -380,18 +246,19 @@ impl ArraySubset {
         if self.is_empty() {
             None
         } else {
-            Some(self.end_exc().iter().map(|i| i - 1).collect())
+            Some(
+                std::iter::zip(&self.start, &self.shape)
+                    .map(|(start, size)| start + size - 1)
+                    .collect(),
+            )
         }
     }
 
     /// Return the end (exclusive) of the array subset.
     #[must_use]
     pub fn end_exc(&self) -> ArrayIndices {
-        izip!(&self.start, &self.shape, &self.integer_indices)
-            .map(|(start, size, maybe_index)| match maybe_index {
-                Some(index) => *index.iter().max().unwrap(),
-                None => start + size,
-            })
+        std::iter::zip(&self.start, &self.shape)
+            .map(|(start, size)| start + size)
             .collect()
     }
 
@@ -413,7 +280,7 @@ impl ArraySubset {
         usize::try_from(self.num_elements()).unwrap()
     }
 
-    /// Returns [`true`] if the array subset contains `indices`.  Does not check integer indices.
+    /// Returns [`true`] if the array subset contains `indices`.
     #[must_use]
     pub fn contains(&self, indices: &[u64]) -> bool {
         izip!(indices, &self.start, &self.shape).all(|(&i, &o, &s)| i >= o && i < o + s)
@@ -423,12 +290,12 @@ impl ArraySubset {
     ///
     /// # Errors
     ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the `array_shape` does not encapsulate this array subset.
+    /// Returns [`IncompatibleIndexerAndShapeError`] if the `array_shape` does not encapsulate this array subset.
     pub fn byte_ranges(
         &self,
         array_shape: &[u64],
         element_size: usize,
-    ) -> Result<Vec<ByteRange>, IncompatibleArraySubsetAndShapeError> {
+    ) -> Result<Vec<ByteRange>, IncompatibleIndexerAndShapeError> {
         let mut byte_ranges: Vec<ByteRange> = Vec::new();
         let contiguous_indices = self.contiguous_linearised_indices(array_shape)?;
         let byte_length = contiguous_indices.contiguous_elements_usize() * element_size;
@@ -465,7 +332,7 @@ impl ArraySubset {
     ///
     /// # Errors
     ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the length of `array_shape` does not match the array subset dimensionality or the array subset is outside of the bounds of `array_shape`.
+    /// Returns [`IncompatibleIndexerAndShapeError`] if the length of `array_shape` does not match the array subset dimensionality or the array subset is outside of the bounds of `array_shape`.
     ///
     /// # Panics
     /// Panics if attempting to access a byte index beyond [`usize::MAX`].
@@ -473,7 +340,7 @@ impl ArraySubset {
         &self,
         elements: &[T],
         array_shape: &[u64],
-    ) -> Result<Vec<T>, IncompatibleArraySubsetAndShapeError> {
+    ) -> Result<Vec<T>, IncompatibleIndexerAndShapeError> {
         if elements.len() as u64 == array_shape.iter().product::<u64>()
             && array_shape.len() == self.dimensionality()
             && self
@@ -484,7 +351,7 @@ impl ArraySubset {
         {
             Ok(unsafe { self.extract_elements_unchecked(elements, array_shape) })
         } else {
-            Err(IncompatibleArraySubsetAndShapeError(
+            Err(IncompatibleIndexerAndShapeError::new(
                 self.clone(),
                 array_shape.to_vec(),
             ))
@@ -535,11 +402,11 @@ impl ArraySubset {
     ///
     /// # Errors
     ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the `array_shape` does not encapsulate this array subset.
+    /// Returns [`IncompatibleIndexerAndShapeError`] if the `array_shape` does not encapsulate this array subset.
     pub fn linearised_indices(
         &self,
         array_shape: &[u64],
-    ) -> Result<LinearisedIndices, IncompatibleArraySubsetAndShapeError> {
+    ) -> Result<LinearisedIndices, IncompatibleIndexerAndShapeError> {
         LinearisedIndices::new(self.clone(), array_shape.to_vec())
     }
 
@@ -557,12 +424,12 @@ impl ArraySubset {
     ///
     /// # Errors
     ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the `array_shape` does not encapsulate this array subset.
+    /// Returns [`IncompatibleIndexerAndShapeError`] if the `array_shape` does not encapsulate this array subset.
     pub fn contiguous_indices(
         &self,
         array_shape: &[u64],
-    ) -> Result<ContiguousIndices, IncompatibleArraySubsetAndShapeError> {
-        ContiguousIndices::new(self, array_shape)
+    ) -> Result<ContiguousIndices, IncompatibleIndexerAndShapeError> {
+        ContiguousIndices::new(self.clone(), array_shape)
     }
 
     /// Returns an iterator over the indices of contiguous elements within the subset.
@@ -572,18 +439,18 @@ impl ArraySubset {
     #[must_use]
     pub unsafe fn contiguous_indices_unchecked(&self, array_shape: &[u64]) -> ContiguousIndices {
         // SAFETY: array_shape encapsulated this array subset
-        unsafe { ContiguousIndices::new_unchecked(self, array_shape) }
+        unsafe { ContiguousIndices::new_unchecked(self.clone(), array_shape) }
     }
 
     /// Returns an iterator over the linearised indices of contiguous elements within the subset.
     ///
     /// # Errors
     ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the `array_shape` does not encapsulate this array subset.
+    /// Returns [`IncompatibleIndexerAndShapeError`] if the `array_shape` does not encapsulate this array subset.
     pub fn contiguous_linearised_indices(
         &self,
         array_shape: &[u64],
-    ) -> Result<ContiguousLinearisedIndices, IncompatibleArraySubsetAndShapeError> {
+    ) -> Result<ContiguousLinearisedIndices, IncompatibleIndexerAndShapeError> {
         ContiguousLinearisedIndices::new(self, array_shape.to_vec())
     }
 
@@ -690,14 +557,11 @@ impl ArraySubset {
     #[must_use]
     pub unsafe fn relative_to_unchecked(&self, start: &[u64]) -> Self {
         debug_assert_eq!(start.len(), self.dimensionality());
-        let len = start.len();
         Self {
             start: std::iter::zip(self.start(), start)
                 .map(|(a, b)| a - b)
                 .collect::<Vec<_>>(),
             shape: self.shape().to_vec(),
-            integer_indices: vec![None; len],
-            indexing_method: IndexingMethod::Basic,
         }
     }
 
@@ -730,73 +594,17 @@ impl IncompatibleDimensionalityError {
     }
 }
 
-/// An incompatible array and array shape error.
-#[derive(Clone, Debug, Error, From)]
-#[error("incompatible array subset {0} with array shape {1:?}")]
-pub struct IncompatibleArraySubsetAndShapeError(ArraySubset, ArrayShape);
-
-impl IncompatibleArraySubsetAndShapeError {
-    /// Create a new incompatible array subset and shape error.
-    #[must_use]
-    pub fn new(array_subset: ArraySubset, array_shape: ArrayShape) -> Self {
-        Self(array_subset, array_shape)
-    }
-}
-
 /// An incompatible start/end indices error.
 #[derive(Clone, Debug, Error, From)]
 #[error("incompatible start {0:?} with end {1:?}")]
 pub struct IncompatibleStartEndIndicesError(ArrayIndices, ArrayIndices);
-
-/// An incompatible integer indexing combination.
-#[derive(Clone, Debug, Error, From)]
-#[error("incompatible start {0:?} with indices {1:?}, shape {2:?}, and indexing method {3:?}")]
-pub struct IncompatibleIntegerIndicesError(
-    ArrayIndices,
-    Vec<Option<ArrayIndices>>,
-    ArrayShape,
-    IndexingMethod,
-);
-
-/// Error enum to allow users to distinguish between different types of possible integer indices contstructor errors.
-#[derive(Debug)]
-pub enum IntegerIndicesError {
-    /// Error for incompatible dimensionality.
-    IncompatibleDimensionalityError(IncompatibleDimensionalityError),
-    /// Error for some form of incompatible integer indices.
-    IncompatibleIntegerIndicesError(IncompatibleIntegerIndicesError),
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn array_subset_end_inc() {
-        assert!(ArraySubset::new_with_start_shape(vec![0, 0], vec![10, 10])
-            .unwrap()
-            .end_inc()
-            .unwrap()
-            .eq(&[9, 9]));
-        assert!(ArraySubset::new_with_start_shape(vec![2, 3], vec![10, 10])
-            .unwrap()
-            .end_inc()
-            .unwrap()
-            .eq(&[11, 12]));
-        let true_val: Vec<u64> = ArraySubset::new_with_start_shape_indices(
-            vec![0, 0],
-            vec![None, vec![0, 7].into()],
-            vec![10, 2],
-            IndexingMethod::Mixed,
-        )
-        .unwrap()
-        .end_inc()
-        .unwrap();
-        assert!(true_val.eq(&[9, 6]), "{:?}", true_val);
-    }
-
-    #[test]
-    fn array_subset_new() {
+    fn array_subset() {
         assert!(ArraySubset::new_with_start_shape(vec![0, 0], vec![10, 10]).is_ok());
         assert!(ArraySubset::new_with_start_shape(vec![0, 0], vec![10]).is_err());
         assert!(ArraySubset::new_with_start_end_inc(vec![0, 0], vec![10, 10]).is_ok());
@@ -838,116 +646,7 @@ mod tests {
                 .into_iter()
                 .next(),
             Some(4 * 1 + 3 * 7 * 1)
-        );
-        assert!(ArraySubset::new_with_start_shape_indices(
-            vec![0, 0],
-            vec![None, None],
-            vec![10, 10],
-            IndexingMethod::Basic
         )
-        .is_ok());
-        assert!(ArraySubset::new_with_start_shape_indices(
-            vec![0, 0],
-            vec![None, vec![0; 10].into()],
-            vec![10, 10],
-            IndexingMethod::Mixed
-        )
-        .is_ok());
-        assert!(ArraySubset::new_with_start_shape_indices(
-            vec![0, 0],
-            vec![vec![0; 10].into(), vec![0; 10].into()],
-            vec![10, 10],
-            IndexingMethod::OIndex
-        )
-        .is_ok());
-        assert!(ArraySubset::new_with_start_shape_indices(
-            vec![0, 0],
-            vec![vec![0; 2].into(), vec![0; 2].into()],
-            vec![2, 1],
-            IndexingMethod::VIndex
-        )
-        .is_ok());
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0, 0],
-                vec![None, vec![0; 10].into()],
-                vec![10, 10],
-                IndexingMethod::Basic
-            ),
-            Err(IntegerIndicesError::IncompatibleIntegerIndicesError(_))
-        ));
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0, 0],
-                vec![vec![0; 10].into(), vec![0; 10].into()],
-                vec![10, 10],
-                IndexingMethod::Basic
-            ),
-            Err(IntegerIndicesError::IncompatibleIntegerIndicesError(_))
-        ));
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0, 0],
-                vec![vec![0; 10].into(), vec![0; 10].into()],
-                vec![9, 10],
-                IndexingMethod::OIndex
-            ),
-            Err(IntegerIndicesError::IncompatibleIntegerIndicesError(_))
-        ));
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0, 0],
-                vec![vec![0; 0].into(), vec![0; 10].into()],
-                vec![10, 10],
-                IndexingMethod::OIndex
-            ),
-            Err(IntegerIndicesError::IncompatibleIntegerIndicesError(_))
-        ));
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0, 0],
-                vec![None],
-                vec![10, 10],
-                IndexingMethod::Basic
-            ),
-            Err(IntegerIndicesError::IncompatibleDimensionalityError(_))
-        ));
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0],
-                vec![None, None],
-                vec![10, 10],
-                IndexingMethod::Basic
-            ),
-            Err(IntegerIndicesError::IncompatibleDimensionalityError(_))
-        ));
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0, 0],
-                vec![vec![0; 3].into(), vec![0; 2].into()],
-                vec![2, 1],
-                IndexingMethod::VIndex
-            ),
-            Err(IntegerIndicesError::IncompatibleIntegerIndicesError(_))
-        ));
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0, 0],
-                vec![vec![0; 2].into(), vec![0; 2].into()],
-                vec![2, 2],
-                IndexingMethod::VIndex
-            ),
-            Err(IntegerIndicesError::IncompatibleIntegerIndicesError(_))
-        ));
-        assert!(matches!(
-            ArraySubset::new_with_start_shape_indices(
-                vec![0, 0],
-                vec![vec![0; 2].into(), vec![0; 2].into()],
-                vec![2],
-                IndexingMethod::VIndex
-            ),
-            Err(IntegerIndicesError::IncompatibleDimensionalityError(_))
-        ));
     }
 
     #[test]

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -243,21 +243,36 @@ impl ArraySubset {
         let all_some_integer_indices = integer_indices.iter().all(|x| x.is_some());
         let any_none_integer_indices = integer_indices.iter().any(|x| x.is_none());
         let is_vindex = indexing_method == IndexingMethod::VIndex;
-        let is_vindex_with_unequal_index_lengths = all_some_integer_indices && is_vindex && !integer_indices.iter().map(|x| x.as_ref().unwrap().len()).all_equal();
-        let is_vindex_with_bad_shape = all_some_integer_indices && is_vindex && (integer_indices[0].as_ref().unwrap().len() != (shape[0] as usize) || shape.iter().skip(1).all_equal_value() != Ok(&1));
+        let is_vindex_with_unequal_index_lengths = all_some_integer_indices
+            && is_vindex
+            && !integer_indices
+                .iter()
+                .map(|x| x.as_ref().unwrap().len())
+                .all_equal();
+        let is_vindex_with_bad_shape = all_some_integer_indices
+            && is_vindex
+            && (integer_indices[0].as_ref().unwrap().len() != (shape[0] as usize)
+                || shape.iter().skip(1).all_equal_value() != Ok(&1));
         let is_incorrect_indexing_method = (all_none_integer_indices
             && indexing_method != IndexingMethod::Basic)
             || (!all_none_integer_indices
                 && any_none_integer_indices
                 && indexing_method != IndexingMethod::Mixed)
-            || (all_some_integer_indices
-                && indexing_method == IndexingMethod::Basic)
+            || (all_some_integer_indices && indexing_method == IndexingMethod::Basic)
             || (any_none_integer_indices && is_vindex);
-        let are_integer_indices_wrong_or_missing = izip!(&shape, &integer_indices).any(|(sh, index)| match index {
-            Some(i) => i.len() == 0 || (indexing_method == IndexingMethod::OIndex && i.len() as u64 != *sh),
-            None => *sh == 0,
-        });
-        if is_incorrect_indexing_method || are_integer_indices_wrong_or_missing || is_vindex_with_unequal_index_lengths || is_vindex_with_bad_shape {
+        let are_integer_indices_wrong_or_missing =
+            izip!(&shape, &integer_indices).any(|(sh, index)| match index {
+                Some(i) => {
+                    i.len() == 0
+                        || (indexing_method == IndexingMethod::OIndex && i.len() as u64 != *sh)
+                }
+                None => *sh == 0,
+            });
+        if is_incorrect_indexing_method
+            || are_integer_indices_wrong_or_missing
+            || is_vindex_with_unequal_index_lengths
+            || is_vindex_with_bad_shape
+        {
             return Err(IntegerIndicesError::IncompatibleIntegerIndicesError(
                 IncompatibleIntegerIndicesError::from((
                     start,
@@ -373,11 +388,9 @@ impl ArraySubset {
     #[must_use]
     pub fn end_exc(&self) -> ArrayIndices {
         izip!(&self.start, &self.shape, &self.integer_indices)
-            .map(|(start, size, maybe_index)| {
-                match maybe_index {
-                    Some(index) => *index.iter().max().unwrap(),
-                    None => start + size,
-                }
+            .map(|(start, size, maybe_index)| match maybe_index {
+                Some(index) => *index.iter().max().unwrap(),
+                None => start + size,
             })
             .collect()
     }
@@ -760,14 +773,25 @@ mod tests {
 
     #[test]
     fn array_subset_end_inc() {
-        assert!(ArraySubset::new_with_start_shape(vec![0, 0], vec![10, 10]).unwrap().end_inc().unwrap().eq(&[9, 9]));
-        assert!(ArraySubset::new_with_start_shape(vec![2, 3], vec![10, 10]).unwrap().end_inc().unwrap().eq(&[11, 12]));
+        assert!(ArraySubset::new_with_start_shape(vec![0, 0], vec![10, 10])
+            .unwrap()
+            .end_inc()
+            .unwrap()
+            .eq(&[9, 9]));
+        assert!(ArraySubset::new_with_start_shape(vec![2, 3], vec![10, 10])
+            .unwrap()
+            .end_inc()
+            .unwrap()
+            .eq(&[11, 12]));
         let true_val: Vec<u64> = ArraySubset::new_with_start_shape_indices(
             vec![0, 0],
             vec![None, vec![0, 7].into()],
             vec![10, 2],
-            IndexingMethod::Mixed
-        ).unwrap().end_inc().unwrap();
+            IndexingMethod::Mixed,
+        )
+        .unwrap()
+        .end_inc()
+        .unwrap();
         assert!(true_val.eq(&[9, 6]), "{:?}", true_val);
     }
 

--- a/zarrs/src/array_subset/iterators/chunks_iterator.rs
+++ b/zarrs/src/array_subset/iterators/chunks_iterator.rs
@@ -232,7 +232,7 @@ impl<'a> Producer for ParChunksIteratorProducer<'a> {
 
     fn into_iter(self) -> Self::IntoIter {
         ChunksIterator {
-            inner: IndicesIterator::new_with_start_end(self.inner.subset, self.inner.range),
+            inner: IndicesIterator::new_with_start_end(self.inner.indexer, self.inner.range),
             chunk_shape: self.chunk_shape,
         }
     }

--- a/zarrs/src/array_subset/iterators/contiguous_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/contiguous_indices_iterator.rs
@@ -96,7 +96,13 @@ impl ContiguousIndices {
         }
         // SAFETY: each element is initialised
         unsafe { shape_out.set_len(array_shape.len()) };
-        let subset_contiguous_start = ArraySubset::new_with_start_shape_indices(subset.start().to_vec(), subset.integer_indices().to_vec(), shape_out, subset.indexing_method).unwrap();
+        let subset_contiguous_start = ArraySubset::new_with_start_shape_indices(
+            subset.start().to_vec(),
+            subset.integer_indices().to_vec(),
+            shape_out,
+            subset.indexing_method,
+        )
+        .unwrap();
         // let inner = subset_contiguous_start.iter_indices();
         Self {
             subset_contiguous_start,

--- a/zarrs/src/array_subset/iterators/contiguous_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/contiguous_indices_iterator.rs
@@ -4,7 +4,8 @@ use itertools::izip;
 
 use crate::{
     array::ArrayIndices,
-    array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError, IndexingMethod},
+    array_subset::{ArraySubset, IncompatibleIndexerAndShapeError},
+    indexer::Indexer,
 };
 
 use super::IndicesIterator;
@@ -30,7 +31,7 @@ use super::IndicesIterator;
 /// [((2, 1), 2), ((3, 1), 2)]
 /// ```
 pub struct ContiguousIndices {
-    subset_contiguous_start: ArraySubset,
+    indexer_contiguous_start: Indexer,
     contiguous_elements: u64,
 }
 
@@ -38,21 +39,14 @@ impl ContiguousIndices {
     /// Create a new contiguous indices iterator.
     ///
     /// # Errors
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if `array_shape` does not encapsulate `subset`.
+    /// Returns [`IncompatibleIndexerAndShapeError`] if `array_shape` does not encapsulate `subset`.
     pub fn new(
-        subset: &ArraySubset,
+        indexer: impl Into<Indexer>,
         array_shape: &[u64],
-    ) -> Result<Self, IncompatibleArraySubsetAndShapeError> {
-        if subset.dimensionality() == array_shape.len()
-            && std::iter::zip(subset.end_exc(), array_shape).all(|(end, shape)| end <= *shape)
-        {
-            Ok(unsafe { Self::new_unchecked(subset, array_shape) })
-        } else {
-            Err(IncompatibleArraySubsetAndShapeError(
-                subset.clone(),
-                array_shape.to_vec(),
-            ))
-        }
+    ) -> Result<Self, IncompatibleIndexerAndShapeError> {
+        let indexer = indexer.into();
+        indexer.is_compatible(array_shape)?;
+        Ok(unsafe { Self::new_unchecked(indexer, array_shape) })
     }
 
     /// Create a new contiguous indices iterator.
@@ -61,59 +55,68 @@ impl ContiguousIndices {
     /// `array_shape` must encapsulate `subset`.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub unsafe fn new_unchecked(subset: &ArraySubset, array_shape: &[u64]) -> Self {
-        debug_assert_eq!(subset.dimensionality(), array_shape.len());
-        debug_assert!(
-            std::iter::zip(subset.end_exc(), array_shape).all(|(end, shape)| end <= *shape)
-        );
+    pub unsafe fn new_unchecked(indexer: impl Into<Indexer>, array_shape: &[u64]) -> Self {
+        let indexer = indexer.into();
+        debug_assert!(indexer.is_compatible(array_shape).is_ok());
 
-        let mut contiguous = true;
-        let mut contiguous_elements = 1;
-        let mut shape_out: Vec<u64> = Vec::with_capacity(array_shape.len());
-        if subset.indexing_method != IndexingMethod::VIndex {
-            for (&subset_start, &subset_size, maybe_integer_index, &array_size, shape_out_i) in izip!(
-                subset.start().iter().rev(),
-                subset.shape().iter().rev(),
-                subset.integer_indices().iter().rev(),
-                array_shape.iter().rev(),
-                shape_out.spare_capacity_mut().iter_mut().rev(),
-            ) {
-                if contiguous {
-                    if maybe_integer_index.is_some() {
-                        shape_out_i.write(subset_size);
-                        contiguous = false;
-                    } else {
+        match indexer {
+            Indexer::Subset(subset) => {
+                let mut contiguous = true;
+                let mut contiguous_elements = 1;
+                let mut shape_out: Vec<u64> = Vec::with_capacity(array_shape.len());
+                for (&subset_start, &subset_size, &array_size, shape_out_i) in izip!(
+                    subset.start().iter().rev(),
+                    subset.shape().iter().rev(),
+                    array_shape.iter().rev(),
+                    shape_out.spare_capacity_mut().iter_mut().rev(),
+                ) {
+                    if contiguous {
                         contiguous_elements *= subset_size;
                         shape_out_i.write(1);
                         contiguous = subset_start == 0 && subset_size == array_size;
+                    } else {
+                        shape_out_i.write(subset_size);
                     }
-                } else {
-                    shape_out_i.write(subset_size);
+                }
+                // SAFETY: each element is initialised
+                unsafe { shape_out.set_len(array_shape.len()) };
+                // SAFETY: The length of shape_out matches the subset dimensionality
+                let subset_contiguous_start = unsafe {
+                    ArraySubset::new_with_start_shape_unchecked(subset.start().to_vec(), shape_out)
+                };
+                Self {
+                    indexer_contiguous_start: Indexer::Subset(subset_contiguous_start),
+                    contiguous_elements,
                 }
             }
-        } else {
-            shape_out = subset.shape().to_vec();
-        }
-        // SAFETY: each element is initialised
-        unsafe { shape_out.set_len(array_shape.len()) };
-        let subset_contiguous_start = ArraySubset::new_with_start_shape_indices(
-            subset.start().to_vec(),
-            subset.integer_indices().to_vec(),
-            shape_out,
-            subset.indexing_method,
-        )
-        .unwrap();
-        // let inner = subset_contiguous_start.iter_indices();
-        Self {
-            subset_contiguous_start,
-            contiguous_elements,
+            Indexer::VIndex(vindices) => {
+                // TODO: integer indexing vindices could have contiguous elements, worth checking?
+                Self {
+                    indexer_contiguous_start: Indexer::VIndex(vindices),
+                    contiguous_elements: 1,
+                }
+            }
+            Indexer::OIndex(oindices) => {
+                // TODO: integer indexing oindices could have contiguous elements, worth checking?
+                Self {
+                    indexer_contiguous_start: Indexer::OIndex(oindices),
+                    contiguous_elements: 1,
+                }
+            }
+            Indexer::Mixed(mindices) => {
+                // TODO: integer indexing mindices could have contiguous elements, worth checking?
+                Self {
+                    indexer_contiguous_start: Indexer::Mixed(mindices),
+                    contiguous_elements: 1,
+                }
+            }
         }
     }
 
     /// Return the number of starting indices (i.e. the length of the iterator).
     #[must_use]
     pub fn len(&self) -> usize {
-        self.subset_contiguous_start.num_elements_usize()
+        self.indexer_contiguous_start.num_elements_usize()
     }
 
     /// Returns true if the number of starting indices is zero.
@@ -150,7 +153,7 @@ impl<'a> IntoIterator for &'a ContiguousIndices {
 
     fn into_iter(self) -> Self::IntoIter {
         ContiguousIndicesIterator {
-            inner: IndicesIterator::new(&self.subset_contiguous_start),
+            inner: IndicesIterator::new(&self.indexer_contiguous_start),
             contiguous_elements: self.contiguous_elements,
         }
     }

--- a/zarrs/src/array_subset/iterators/contiguous_linearised_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/contiguous_linearised_indices_iterator.rs
@@ -2,7 +2,7 @@ use std::iter::FusedIterator;
 
 use crate::{
     array::ravel_indices,
-    array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError},
+    array_subset::{ArraySubset, IncompatibleIndexerAndShapeError},
 };
 
 use super::{contiguous_indices_iterator::ContiguousIndices, ContiguousIndicesIterator};
@@ -37,11 +37,11 @@ impl ContiguousLinearisedIndices {
     ///
     /// # Errors
     ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if `array_shape` does not encapsulate `subset`.
+    /// Returns [`IncompatibleIndexerAndShapeError`] if `array_shape` does not encapsulate `subset`.
     pub fn new(
         subset: &ArraySubset,
         array_shape: Vec<u64>,
-    ) -> Result<Self, IncompatibleArraySubsetAndShapeError> {
+    ) -> Result<Self, IncompatibleIndexerAndShapeError> {
         let inner = subset.contiguous_indices(&array_shape)?;
         Ok(Self { inner, array_shape })
     }

--- a/zarrs/src/indexer.rs
+++ b/zarrs/src/indexer.rs
@@ -1,0 +1,169 @@
+use derive_more::{
+    derive::{Deref, Display},
+    From,
+};
+use thiserror::Error;
+use zarrs_metadata::ArrayShape;
+
+use crate::{array::ArrayIndices, array_subset::ArraySubset};
+
+#[derive(Clone, Display, Debug, Deref)]
+#[display("{_0:?}")]
+pub struct VIndices(Vec<ArrayIndices>);
+
+impl TryFrom<Vec<ArrayIndices>> for VIndices {
+    type Error = Vec<ArrayIndices>; // FIXME: integer indexing InvalidVIndices
+
+    fn try_from(value: Vec<ArrayIndices>) -> Result<Self, Self::Error> {
+        // FIXME: integer indexing Validate
+        Ok(Self(value))
+    }
+}
+
+#[derive(Clone, Display, Debug, Deref)]
+#[display("{_0:?}")]
+pub struct OIndices(Vec<ArrayIndices>);
+
+impl TryFrom<Vec<ArrayIndices>> for OIndices {
+    type Error = Vec<ArrayIndices>; // FIXME: integer indexing InvalidOIndices
+
+    fn try_from(value: Vec<ArrayIndices>) -> Result<Self, Self::Error> {
+        // FIXME: integer indexing Validate
+        Ok(Self(value))
+    }
+}
+
+#[derive(Clone, Display, Debug, Deref)]
+#[display("{_0:?}")]
+pub struct MixedIndices(Vec<MixedIndex>);
+
+impl TryFrom<Vec<MixedIndex>> for MixedIndices {
+    type Error = Vec<MixedIndex>; // FIXME: integer indexing InvalidMixedIndices
+
+    fn try_from(value: Vec<MixedIndex>) -> Result<Self, Self::Error> {
+        // FIXME: Validate
+        Ok(Self(value))
+    }
+}
+
+/// The indices on a single dimension of [`MixedIndices`].
+#[derive(Clone, Debug, From)]
+pub enum MixedIndex {
+    OIndex(ArrayIndices),
+    Range(std::ops::Range<u64>),
+}
+
+impl MixedIndex {
+    // # Panics
+    // Panics if the length of a range exceeds [`usize::MAX`].
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::OIndex(oindex) => oindex.len(),
+            Self::Range(range) => usize::try_from(range.end.saturating_sub(range.start)).unwrap(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// An incompatible indexer and array shape error.
+#[derive(Clone, Debug, Error, From)]
+#[error("incompatible indexer {0} with array shape {1:?}")]
+pub struct IncompatibleIndexerAndShapeError(Indexer, ArrayShape);
+
+impl IncompatibleIndexerAndShapeError {
+    /// Create a new incompatible indexer and shape error.
+    #[must_use]
+    pub fn new(indexer: impl Into<Indexer>, array_shape: ArrayShape) -> Self {
+        let indexer = indexer.into();
+        Self(indexer, array_shape)
+    }
+}
+
+/// The different kinds of array indexing methods.
+///
+/// See: <https://numpy.org/neps/nep-0021-advanced-indexing.html#existing-indexing-operations>
+#[derive(Clone, Display, Debug, From)]
+pub enum Indexer {
+    /// Subset indexing.
+    // Is this just basic?
+    Subset(ArraySubset),
+    /// Vectorized Indexing.
+    VIndex(VIndices),
+    /// Orthogonal Indexing.
+    OIndex(OIndices),
+    /// Mixed Indexing, a variant of vectorized where integer indices are treated as vectorized but with ranges too.
+    Mixed(MixedIndices),
+}
+
+impl Indexer {
+    #[must_use]
+    pub fn new_subset(subset: ArraySubset) -> Self {
+        Self::Subset(subset)
+    }
+
+    // TODO: integer indexing
+    // pub fn new_mixed(vindices: Vec<ArrayIndices>) -> Result<Self, InvalidMixedIndices> {
+    //     let vindinces: VIndices = vindices.try_into()
+    // }
+
+    // pub fn new_vindex(vindices: Vec<ArrayIndices>) -> Result<Self, InvalidVIndices> {
+    //     let vindinces: VIndices = vindices.try_into()
+    // }
+
+    // pub fn new_oindex(vindices: Vec<ArrayIndices>) -> Result<Self, InvalidOIndices> {
+    //     let vindinces: VIndices = vindices.try_into()
+    // }
+
+    /// Return the dimensionality of the indexer.
+    #[must_use]
+    pub fn dimensionality(&self) -> usize {
+        match self {
+            Indexer::Subset(subset) => subset.dimensionality(),
+            Indexer::VIndex(vindices) => vindices.len(),
+            Indexer::OIndex(oindices) => oindices.len(),
+            Indexer::Mixed(mindices) => mindices.len(),
+        }
+    }
+
+    /// Return the number of elements of the indexer.
+    #[must_use]
+    pub fn num_elements_usize(&self) -> usize {
+        match self {
+            Indexer::Subset(subset) => subset.num_elements_usize(),
+            Indexer::VIndex(vindices) => vindices.first().map_or(0, Vec::len),
+            Indexer::OIndex(oindices) => oindices.iter().map(Vec::len).product(),
+            Indexer::Mixed(mindices) => mindices.iter().map(MixedIndex::len).product(),
+        }
+    }
+
+    /// Check if the indexer is compatible with an array of shape `array_shape`.
+    pub fn is_compatible(
+        &self,
+        array_shape: &[u64],
+    ) -> Result<(), IncompatibleIndexerAndShapeError> {
+        // TODO: integer indexing or bool?
+        let compatible = match self {
+            Indexer::Subset(subset) => {
+                subset.dimensionality() == array_shape.len()
+                    && std::iter::zip(subset.end_exc(), array_shape)
+                        .all(|(end, shape)| end <= *shape)
+            }
+            Indexer::VIndex(vindices) => todo!("integer indexing"),
+            Indexer::OIndex(oindices) => todo!("integer indexing"),
+            Indexer::Mixed(mindices) => todo!("integer indexing"),
+        };
+        if compatible {
+            Ok(())
+        } else {
+            Err(IncompatibleIndexerAndShapeError(
+                self.clone(),
+                array_shape.to_vec(),
+            ))
+        }
+    }
+}

--- a/zarrs/src/lib.rs
+++ b/zarrs/src/lib.rs
@@ -188,6 +188,7 @@ pub mod array;
 pub mod array_subset;
 pub mod config;
 pub mod group;
+pub mod indexer;
 pub mod node;
 pub mod plugin;
 pub mod version;


### PR DESCRIPTION
- https://github.com/LDeakin/zarrs/pull/102

This leaves `ArraySubset` untouched and adds `Indexer` representing multiple indexing methods[^1]. I hope the new types in `Indexer` represent each method correctly. Your tests pass, but I didn't thoroughly research the exact semantics of `VIndex`/`OIndex`/`Mixed` in numpy.

Docs are missing and there are a few `TODO: integer indexing`, `FIXME: integer indexing` and `todo!("integer indexing")`. `update_bytes_flen` and a few other methods around the codebase need to be adapted to take `indexer: impl Into<Indexer>` instead of `subset: ArraySubset`, for example.

[^1]: I've tried to push more into the type system (i.e. [compiler-driven development](https://youtu.be/Kdpfhj3VM04?t=431)) to avoid complicated logic like [this]( https://github.com/LDeakin/zarrs/blob/3c5d2729f1942ab1a8a2f3eb1581e7737ceb5ca4/zarrs/src/array_subset.rs#L242-L260).